### PR TITLE
fix example for modern java version

### DIFF
--- a/example/project.clj
+++ b/example/project.clj
@@ -19,6 +19,7 @@
                     :output-to "resources/public/js/main.js"
                     :output-dir "resources/public/js/out"
                     :optimizations :none}}}}
+  :jvm-opts ["--add-modules" "java.xml.bind"]
   :figwheel
   {:http-server-root "public"
    :server-port      3001


### PR DESCRIPTION
The example complains about `Exception in thread "main" java.lang.ClassNotFoundException: javax.xml.bind.DatatypeConverter, compiling:(cljs/closure.clj:1:1)`.